### PR TITLE
feat: implemnet metrics server

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,28 +62,33 @@ curl -X 'POST' http://localhost:8080/approve -d '{"token_symbol": "BNB","owner_p
 | http.addr | HTTP_ADDR | string | | HTTP address | `"0.0.0.0"` |
 | http.port | HTTP_PORT | uint16 | | HTTP port | `8080` |
 |---|---|---|---|---|---|
+| metrics.enable | METRICS_ENABLE | bool | | Whether to enable metrics router | `true` |
+| metrics.pprof | METRICS_PPROF | bool | | Whether to enable pprof router | `false` |
+| metrics.path | METRICS_PATH | string | | Metrics router path | `/metrics` |
+| metrics.addr | METRICS_ADDR | string | | Metrics address | `"0.0.0.0"` |
+| metrics.port | METRICS_PORT | uint16 | | Metrics port | `6060` |
+|---|---|---|---|---|---|
 | secret.type | SECRET_TYPE | string | | Secret type | `"local"` |
-| secret.local_secret.private_key | SECRET_LOCAL_PRIVATE_KEY | string | | Local secret private key | `""` |
-| secret.aws_secret_manager.region | SECRET_AWS_REGION | string | | AWS Secret Manager region | `""` |
-| secret.aws_secret_manager.secret_name | SECRET_AWS_SECRET_NAME | string | | AWS Secret Manager secret name | `""` |
+| secret.local_secret.private_key | SECRET_LOCAL_SECRET_PRIVATE_KEY | string | | Local secret private key | `""` |
+| secret.aws_secret_manager.region | SECRET_AWS_SECRET_MANAGER_REGION | string | | AWS Secret Manager region | `""` |
+| secret.aws_secret_manager.secret_name | SECRET_AWS_SECRET_MANAGER_SECRET_NAME | string | | AWS Secret Manager secret name | `""` |
 |---|---|---|---|---|---|
 | store.driver | STORE_DRIVER | string | | Store driver | `"memory"` |
 |---|---|---|---|---|---|
-| store.memory_store.accounts | STORE_MEMORY_ACCOUNTS | string | | Memory store accounts file | `"./example/accounts.json"` |
-| store.memory_store.merkle_proofs | STORE_MEMORY_MERKLE_PROOFS | string | | Memory store Merkle proofs file | `"./example/merkle_proofs.json"` |
+| store.memory_store.merkle_proofs | STORE_MEMORY_STORE_MERKLE_PROOFS | string | | Memory store Merkle proofs file | `"./example/merkle_proofs.json"` |
 |---|---|---|---|---|---|
-| store.sql_store.sql_driver | STORE_SQL_DRIVER | string | `mysql`, `postgres`, `sqlite` | SQL store driver | `"mysql"` |
-| store.sql_store.host | STORE_SQL_HOST | string | | SQL store host | `"localhost"` |
-| store.sql_store.port | STORE_SQL_PORT | uint | | SQL store port | `3306` |
-| store.sql_store.dbname | STORE_SQL_DBNAME | string | | SQL store database name | `"approver"` |
-| store.sql_store.user | STORE_SQL_USER | string | | SQL store user | `"root"` |
-| store.sql_store.password | STORE_SQL_PASSWORD | string | | SQL store password | `""` |
-| store.sql_store.connect_timeout | STORE_SQL_CONNECT_TIMEOUT | string | | SQL store connect timeout | `"10s"` |
-| store.sql_store.read_timeout | STORE_SQL_READ_TIMEOUT | string | | SQL store read timeout | `"30s"` |
-| store.sql_store.write_timeout | STORE_SQL_WRITE_TIMEOUT | string | | SQL store write timeout | `"30s"` |
-| store.sql_store.dial_timeout | STORE_SQL_DIAL_TIMEOUT | time.Duration | | SQL store dial timeout | `"10s"` |
-| store.sql_store.max_idletime | STORE_SQL_MAX_IDLETIME | time.Duration | | SQL store max idle time | `"1h"` |
-| store.sql_store.max_lifetime | STORE_SQL_MAX_LIFETIME | time.Duration | | SQL store max lifetime | `"1h"` |
-| store.sql_store.max_idle_conn | STORE_SQL_MAX_IDLE_CONN | int | | SQL store max idle connections | `2` |
-| store.sql_store.max_open_conn | STORE_SQL_MAX_OPEN_CONN | int | | SQL store max open connections | `5` |
-| store.sql_store.ssl_mode | STORE_SQL_SSL_MODE | bool | | SQL store SSL mode | `false` |
+| store.sql_store.sql_driver | STORE_SQL_STORE_SQL_DRIVER | string | `mysql`, `postgres`, `sqlite` | SQL store driver | `"mysql"` |
+| store.sql_store.host | STORE_SQL_STORE_HOST | string | | SQL store host | `"localhost"` |
+| store.sql_store.port | STORE_SQL_STORE_PORT | uint | | SQL store port | `3306` |
+| store.sql_store.dbname | STORE_SQL_STORE_DBNAME | string | | SQL store database name | `"approver"` |
+| store.sql_store.user | STORE_SQL_STORE_USER | string | | SQL store user | `"root"` |
+| store.sql_store.password | STORE_SQL_STORE_PASSWORD | string | | SQL store password | `""` |
+| store.sql_store.connect_timeout | STORE_SQL_STORE_CONNECT_TIMEOUT | string | | SQL store connect timeout | `"10s"` |
+| store.sql_store.read_timeout | STORE_SQL_STORE_READ_TIMEOUT | string | | SQL store read timeout | `"30s"` |
+| store.sql_store.write_timeout | STORE_SQL_STORE_WRITE_TIMEOUT | string | | SQL store write timeout | `"30s"` |
+| store.sql_store.dial_timeout | STORE_SQL_STORE_DIAL_TIMEOUT | time.Duration | | SQL store dial timeout | `"10s"` |
+| store.sql_store.max_idletime | STORE_SQL_STORE_MAX_IDLETIME | time.Duration | | SQL store max idle time | `"1h"` |
+| store.sql_store.max_lifetime | STORE_SQL_STORE_MAX_LIFETIME | time.Duration | | SQL store max lifetime | `"1h"` |
+| store.sql_store.max_idle_conn | STORE_SQL_STORE_MAX_IDLE_CONN | int | | SQL store max idle connections | `2` |
+| store.sql_store.max_open_conn | STORE_SQL_STORE_MAX_OPEN_CONN | int | | SQL store max open connections | `5` |
+| store.sql_store.ssl_mode | STORE_SQL_STORE_SSL_MODE | bool | | SQL store SSL mode | `false` |

--- a/configs/default.config.yaml
+++ b/configs/default.config.yaml
@@ -13,7 +13,7 @@ http:
   port: 8080
 
 metrics:
-  enable: false
+  enable: true
   pprof: false
   path: /metrics
   addr: 0.0.0.0
@@ -27,5 +27,4 @@ secret:
 store:
   driver: memory
   memory_store:
-    accounts: ./example/store/accounts.json
     merkle_proofs: ./example/store/merkle_proofs.json

--- a/configs/default.config.yaml
+++ b/configs/default.config.yaml
@@ -1,6 +1,9 @@
 chain_id: Binance-Chain-Ganges
 merkle_root: 0xad78b6dbdb34cb9a5c0e44fbfcc3bd52d6e9d519eefbfc39ba5c3b232849a064
 
+# account_white_list:
+#   - tbnb1wf7d5t6afrm05zmq9hw66uguae85cpsjcpddtw
+
 logger:
   level: DEBUG
   format: console # json, console

--- a/configs/default.config.yaml
+++ b/configs/default.config.yaml
@@ -12,6 +12,13 @@ http:
   addr: 0.0.0.0
   port: 8080
 
+metrics:
+  enable: false
+  pprof: false
+  path: /metrics
+  addr: 0.0.0.0
+  port: 6060
+
 secret:
   type: local
   local_secret:

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/etcd-io/bbolt v1.3.3 // indirect
+	github.com/felixge/fgprof v0.9.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-kit/kit v0.10.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
@@ -48,6 +49,8 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/btree v1.0.0 // indirect
+	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
+	github.com/gorilla/context v1.1.2 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
@@ -58,6 +61,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jessicalins/instrumentation-practices-examples/middleware v0.0.0-20221107214607-4a1cf17820a6 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
@@ -103,6 +107,7 @@ require (
 	github.com/zondax/ledger-cosmos-go v0.9.9 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/net v0.11.0 // indirect
+	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.9.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHj
 github.com/ethereum/go-ethereum v1.12.2 h1:eGHJ4ij7oyVqUQn48LBz3B7pvQ8sV0wGJiIE6gDq/6Y=
 github.com/ethereum/go-ethereum v1.12.2/go.mod h1:1cRAEV+rp/xX0zraSCBnu9Py3HQ+geRMj3HdR+k0wfI=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/fgprof v0.9.3 h1:VvyZxILNuCiUCSXtPtYmmtGvb65nqXh2QFWc0Wpf2/g=
+github.com/felixge/fgprof v0.9.3/go.mod h1:RdbpDgzqYVh/T9fPELJyV7EYJuHB55UTEULNun8eiPw=
 github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -297,6 +299,9 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
+github.com/google/pprof v0.0.0-20230207041349-798e818bf904 h1:4/hN5RUoecvl+RmJRE2YxKWtnnQls6rQjjW5oV7qg2U=
+github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8qtYCYyzA+8c/9qtqgA3qsXGYqCPKARAFg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -307,6 +312,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/context v1.1.2 h1:WRkNAv2uoa03QNIc1A6u4O7DAGMUVoopZhkiXWA2V1o=
+github.com/gorilla/context v1.1.2/go.mod h1:KDPwT9i/MeWHiLl90fuTgrt4/wPcv75vFAZLaOOcbxM=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
@@ -353,6 +360,7 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
@@ -368,6 +376,8 @@ github.com/jackc/pgx/v5 v5.4.3 h1:cxFyXhxlvAifxnkKKdlxv8XqUf59tDlYjnV5YYfsJJY=
 github.com/jackc/pgx/v5 v5.4.3/go.mod h1:Ig06C2Vu0t5qXC60W8sqIthScaEnFvojjj9dSljmHRA=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jessicalins/instrumentation-practices-examples/middleware v0.0.0-20221107214607-4a1cf17820a6 h1:gMIVsvdjO2s1Tf7+shHq/VrdZDEdegXWnxG+4ktCwiY=
+github.com/jessicalins/instrumentation-practices-examples/middleware v0.0.0-20221107214607-4a1cf17820a6/go.mod h1:PzcIrN1y/mbzGizKbGmaDh4ISvqdrJKxfoON7Y7BzUs=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
@@ -793,6 +803,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -854,6 +866,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/app/inject.go
+++ b/internal/app/inject.go
@@ -3,6 +3,8 @@ package app
 import (
 	"fmt"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/bnb-chain/token-recover-approver/internal/config"
 	"github.com/bnb-chain/token-recover-approver/internal/module/http"
 	"github.com/bnb-chain/token-recover-approver/internal/version"
@@ -18,8 +20,20 @@ type Application struct {
 
 func (application Application) Start() error {
 	application.logger.Info().Str("app_version", version.AppVersion).Str("git_commit", version.GitCommit).Str("git_commit_date", version.GitCommitDate).Msg("version info")
-	application.logger.Info().Msgf("http server listen %s:%d", application.config.HTTP.Addr, application.config.HTTP.Port)
-	return application.httpServer.Run(fmt.Sprintf("%s:%d", application.config.HTTP.Addr, application.config.HTTP.Port))
+	eg := errgroup.Group{}
+	eg.Go(func() error {
+		application.logger.Info().Msgf("http server listen %s:%d", application.config.HTTP.Addr, application.config.HTTP.Port)
+		return application.httpServer.Run(fmt.Sprintf("%s:%d", application.config.HTTP.Addr, application.config.HTTP.Port))
+	})
+	eg.Go(func() error {
+		if !application.config.Metrics.Enable {
+			return nil
+		}
+		application.logger.Info().Msgf("metrics server listen %s:%d", application.config.HTTP.Addr, application.config.HTTP.Port)
+		return application.httpServer.RunMetrics(fmt.Sprintf("%s:%d", application.config.Metrics.Addr, application.config.Metrics.Port), application.config.Metrics.Path, application.config.Metrics.PProf)
+	})
+
+	return eg.Wait()
 }
 
 func (application Application) Stop() error {

--- a/internal/app/wire.go
+++ b/internal/app/wire.go
@@ -21,6 +21,8 @@ func Initialize(configPath string) (Application, error) {
 		injection.InitLogger,
 		injection.InitKeyManager,
 		injection.InitStore,
+		injection.InitMetrics,
+		injection.InitPrometheusRegister,
 		approval.NewApprovalService,
 		http.NewHttpServer,
 	)

--- a/internal/app/wire_gen.go
+++ b/internal/app/wire_gen.go
@@ -32,11 +32,13 @@ func Initialize(configPath string) (Application, error) {
 	if err != nil {
 		return Application{}, err
 	}
-	approvalService, err := approval.NewApprovalService(configConfig, keyManager, store, logger)
+	registry := injection.InitPrometheusRegister()
+	metrics := injection.InitMetrics(registry)
+	approvalService, err := approval.NewApprovalService(configConfig, keyManager, store, metrics, logger)
 	if err != nil {
 		return Application{}, err
 	}
-	httpServer := http.NewHttpServer(approvalService, logger)
+	httpServer := http.NewHttpServer(approvalService, registry, logger)
 	application := newApplication(logger, configConfig, httpServer)
 	return application, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,13 +12,14 @@ import (
 )
 
 type Config struct {
-	ChainID          string       `mapstructure:"chain_id"`
-	MerkleRoot       string       `mapstructure:"merkle_root"`
-	Logger           LoggerConfig `mapstructure:"logger"`
-	HTTP             HTTPConfig   `mapstructure:"http"`
-	Secret           SecretConfig `mapstructure:"secret"`
-	Store            StoreConfig  `mapstructure:"store"`
-	AccountWhiteList []string     `mapstructure:"account_white_list"`
+	ChainID          string        `mapstructure:"chain_id"`
+	MerkleRoot       string        `mapstructure:"merkle_root"`
+	Logger           LoggerConfig  `mapstructure:"logger"`
+	HTTP             HTTPConfig    `mapstructure:"http"`
+	Metrics          MetricsConfig `mapstructure:"metrics"`
+	Secret           SecretConfig  `mapstructure:"secret"`
+	Store            StoreConfig   `mapstructure:"store"`
+	AccountWhiteList []string      `mapstructure:"account_white_list"`
 }
 
 func defaultConfig(v *viper.Viper) {
@@ -45,6 +46,22 @@ type HTTPConfig struct {
 func defaultHTTPConfig(v *viper.Viper) {
 	v.SetDefault("http.addr", "0.0.0.0")
 	v.SetDefault("http.port", 8080)
+}
+
+type MetricsConfig struct {
+	Enable bool   `mapstructure:"enable"`
+	PProf  bool   `mapstructure:"pprof"`
+	Path   string `mapstructure:"path"`
+	Addr   string `mapstructure:"addr"`
+	Port   uint16 `mapstructure:"port"`
+}
+
+func defaultMetricsConfig(v *viper.Viper) {
+	v.SetDefault("metrics.enable", true)
+	v.SetDefault("metrics.pprof", false)
+	v.SetDefault("metrics.path", "/metrics")
+	v.SetDefault("metrics.addr", "0.0.0.0")
+	v.SetDefault("metrics.port", 6060)
 }
 
 type SecretConfig struct {
@@ -140,6 +157,7 @@ func NewConfig(configPath string) (*Config, error) {
 	defaultConfig(v)
 	defaultLoggerConfig(v)
 	defaultHTTPConfig(v)
+	defaultMetricsConfig(v)
 	defaultSecretConfig(v)
 	defaultStoreConfig(v)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,7 +76,6 @@ type StoreConfig struct {
 }
 
 type MemoryStoreConfig struct {
-	Accounts     string `mapstructure:"accounts"`
 	MerkleProofs string `mapstructure:"merkle_proofs"`
 }
 

--- a/internal/injection/inject_metrics.go
+++ b/internal/injection/inject_metrics.go
@@ -1,0 +1,16 @@
+package injection
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/bnb-chain/token-recover-approver/internal/metrics"
+	collector "github.com/bnb-chain/token-recover-approver/internal/metrics/prometheus"
+)
+
+func InitPrometheusRegister() *prometheus.Registry {
+	return prometheus.NewRegistry()
+}
+
+func InitMetrics(registry *prometheus.Registry) metrics.Metrics {
+	return collector.NewCollector(registry)
+}

--- a/internal/injection/inject_store.go
+++ b/internal/injection/inject_store.go
@@ -37,7 +37,6 @@ func InitStore(config *config.Config, logger *zerolog.Logger) (store.Store, erro
 	switch StoreType(config.Store.Driver) {
 	case MemoryStore:
 		return memory.NewMemoryStore(
-			config.Store.MemoryStore.Accounts,
 			config.Store.MemoryStore.MerkleProofs,
 		)
 	case GORMStore:

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,9 @@
+package metrics
+
+type Metrics interface {
+	IncApprovalCount()
+	IncApprovalErrorCount()
+	ObserveApprovalDuration(time float64)
+	ObserveMerkleProofVerificationDuration(time float64)
+	ObserveGetProofDataDuration(time float64)
+}

--- a/internal/metrics/prometheus/collector.go
+++ b/internal/metrics/prometheus/collector.go
@@ -1,0 +1,127 @@
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+
+	"github.com/bnb-chain/token-recover-approver/internal/metrics"
+	"github.com/bnb-chain/token-recover-approver/internal/version"
+)
+
+var _ metrics.Metrics = (*Collector)(nil)
+
+func NewCollector(registry *prometheus.Registry) *Collector {
+	// Add go runtime metrics and process collectors.
+	registry.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+	)
+
+	// Add custom metrics.
+	versionInfo := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "version_info",
+		Help: "Version information about this binary",
+		ConstLabels: prometheus.Labels{
+			"version":    version.AppVersion,
+			"git_commit": version.GitCommit,
+			"build_date": version.GitCommitDate,
+		},
+	})
+	approvalCount := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "approval_count",
+		Help: "The total number of approvals.",
+	})
+	approvalErrorCount := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "approval_error_count",
+		Help: "The total number of approval errors.",
+	})
+	approvalDuration := prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Name: "approval_duration_seconds",
+			Help: "A summary of the approval duration of the requests.",
+			Objectives: map[float64]float64{
+				0:    0.0,
+				0.25: 0.05,
+				0.5:  0.001,
+				0.75: 0.001,
+				1:    0.0,
+			},
+		},
+	)
+	getProofDataDuration := prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Name: "get_proof_data_duration_seconds",
+			Help: "A summary of the get proof data duration of the requests.",
+			Objectives: map[float64]float64{
+				0:    0.0,
+				0.25: 0.05,
+				0.5:  0.001,
+				0.75: 0.001,
+				1:    0.0,
+			},
+		},
+	)
+	merkleProofVerificationDuration := prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Name: "merkle_proof_verification_duration_seconds",
+			Help: "A summary of the merkle proof verification duration of the requests.",
+			Objectives: map[float64]float64{
+				0:    0.0,
+				0.25: 0.05,
+				0.5:  0.001,
+				0.75: 0.001,
+				1:    0.0,
+			},
+		},
+	)
+
+	registry.MustRegister(
+		versionInfo,
+		approvalCount,
+		approvalErrorCount,
+		approvalDuration,
+		getProofDataDuration,
+		merkleProofVerificationDuration,
+	)
+
+	return &Collector{
+		approvalCount:                   approvalCount,
+		approvalErrorCount:              approvalErrorCount,
+		approvalDuration:                approvalDuration,
+		getProofDataDuration:            getProofDataDuration,
+		merkleProofVerificationDuration: merkleProofVerificationDuration,
+	}
+}
+
+type Collector struct {
+	approvalCount                   prometheus.Counter
+	approvalErrorCount              prometheus.Counter
+	approvalDuration                prometheus.Summary
+	getProofDataDuration            prometheus.Summary
+	merkleProofVerificationDuration prometheus.Summary
+}
+
+// ObserveApprovalDuration implements metrics.Metrics.
+func (c *Collector) ObserveApprovalDuration(time float64) {
+	c.approvalDuration.Observe(time)
+}
+
+// ObserveGetProofDataDuration implements metrics.Metrics.
+func (c *Collector) ObserveGetProofDataDuration(time float64) {
+	c.getProofDataDuration.Observe(time)
+}
+
+// ObserveMerkleProofVerificationDuration implements metrics.Metrics.
+func (c *Collector) ObserveMerkleProofVerificationDuration(time float64) {
+	c.merkleProofVerificationDuration.Observe(time)
+}
+
+// IncApprovalCount implements metrics.Metrics.
+func (c *Collector) IncApprovalCount() {
+	c.approvalCount.Inc()
+}
+
+// IncApprovalErrorCount implements metrics.Metrics.
+func (c *Collector) IncApprovalErrorCount() {
+	c.approvalErrorCount.Inc()
+}

--- a/internal/module/approval/approval.go
+++ b/internal/module/approval/approval.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -16,6 +17,7 @@ import (
 	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
 
 	"github.com/bnb-chain/token-recover-approver/internal/config"
+	"github.com/bnb-chain/token-recover-approver/internal/metrics"
 	"github.com/bnb-chain/token-recover-approver/internal/store"
 	"github.com/bnb-chain/token-recover-approver/pkg/keymanager"
 	"github.com/bnb-chain/token-recover-approver/pkg/util"
@@ -28,10 +30,11 @@ type ApprovalService struct {
 	store            store.Store
 	accountWhiteList map[string]struct{}
 
-	logger *zerolog.Logger
+	metrics metrics.Metrics
+	logger  *zerolog.Logger
 }
 
-func NewApprovalService(config *config.Config, km keymanager.KeyManager, store store.Store, logger *zerolog.Logger) (*ApprovalService, error) {
+func NewApprovalService(config *config.Config, km keymanager.KeyManager, store store.Store, metrics metrics.Metrics, logger *zerolog.Logger) (*ApprovalService, error) {
 	accountWhiteList := make(map[string]struct{})
 	for _, addr := range config.AccountWhiteList {
 		accountWhiteList[addr] = struct{}{}
@@ -40,7 +43,7 @@ func NewApprovalService(config *config.Config, km keymanager.KeyManager, store s
 	if err != nil {
 		return nil, err
 	}
-	return &ApprovalService{km: km, store: store, config: config, merkleRoot: merkleRoot, accountWhiteList: accountWhiteList, logger: logger}, nil
+	return &ApprovalService{km: km, store: store, config: config, merkleRoot: merkleRoot, accountWhiteList: accountWhiteList, metrics: metrics, logger: logger}, nil
 }
 
 func (svc *ApprovalService) checkWhiteList(acc types.AccAddress) bool {
@@ -52,59 +55,76 @@ func (svc *ApprovalService) checkWhiteList(acc types.AccAddress) bool {
 	return ok
 }
 
-func (svc *ApprovalService) GetTokenRecoverApproval(req *GetTokenRecoverApprovalRequest) (resp *GetTokenRecoverApprovalResponse, err error) {
+func (svc *ApprovalService) GetTokenRecoverApproval(req *GetTokenRecoverApprovalRequest) (*GetTokenRecoverApprovalResponse, error) {
+	approvalStartTime := time.Now()
 	ownerPubKeyBytes, err := hexutil.Decode(req.OwnerPubKey)
 	if err != nil {
+		svc.metrics.IncApprovalErrorCount()
 		return nil, err
 	}
 	ownerAddr, err := svc.getAddressFromPubKey(ownerPubKeyBytes)
 	if err != nil {
+		svc.metrics.IncApprovalErrorCount()
 		return nil, err
 	}
 	ownerSignature, err := hexutil.Decode(req.OwnerSignature)
 	if err != nil {
+		svc.metrics.IncApprovalErrorCount()
 		return nil, err
 	}
 
 	svc.logger.Info().Str("address", ownerAddr.String()).Msg("GetTokenRecoverApproval")
 	// Check While List
 	if !svc.checkWhiteList(ownerAddr) {
+		svc.metrics.IncApprovalErrorCount()
 		return nil, errors.New("address is not in while list")
 	}
 
 	// Get Merkle Proofs and Node
+	getProofsStartTime := time.Now()
 	proof, err := svc.store.GetAccountAssetProof(ownerAddr, req.TokenSymbol)
 	if err != nil {
+		svc.metrics.IncApprovalErrorCount()
 		return nil, err
 	}
+	svc.metrics.ObserveGetProofDataDuration(float64(time.Since(getProofsStartTime).Seconds()))
 	svc.logger.Debug().Interface("proof", proof).Msg("GetAccountAssetProofs")
 
 	// Check if token amount is zero
 	if proof.Amount == 0 {
+		svc.metrics.IncApprovalErrorCount()
 		return nil, errors.New("token amount is zero")
 	}
 	// Verify user signature
 	tokenRecoverRequestMsg := recover.NewTokenRecoverRequestMsg(req.TokenSymbol, uint64(proof.Amount), strings.ToLower(req.ClaimAddress.Hex()))
 	msgBytes, err := svc.getStdMsgBytes(tokenRecoverRequestMsg)
 	if err != nil {
+		svc.metrics.IncApprovalErrorCount()
 		return nil, err
 	}
 	svc.logger.Debug().Str("msg", string(msgBytes)).Msg("GetStdMsgBytes")
 	err = svc.verifyTmSignature(ownerPubKeyBytes, ownerSignature, msgBytes)
 	if err != nil {
+		svc.metrics.IncApprovalErrorCount()
 		return nil, err
 	}
 
 	nodeBytes, err := proof.Serialize()
 	if err != nil {
+		svc.metrics.IncApprovalErrorCount()
 		return nil, err
 	}
 	svc.logger.Debug().Str("leaf", hexutil.Encode(nodeBytes)).Msg("LeafNodeBytes")
 
+	// Verify merkle proof
+	merkleProofVerificationStartTime := time.Now()
 	if !util.VerifyMerkleProof(svc.merkleRoot, proof.Proof, nodeBytes) {
+		svc.metrics.IncApprovalErrorCount()
 		return nil, errors.New("verify merkle proof failed")
 	}
+	svc.metrics.ObserveMerkleProofVerificationDuration(float64(time.Since(merkleProofVerificationStartTime).Seconds()))
 
+	// Sign ApprovalSignature
 	var tokenSymbolBytes [32]byte
 	copy(tokenSymbolBytes[:], []byte(req.TokenSymbol))
 
@@ -117,9 +137,13 @@ func (svc *ApprovalService) GetTokenRecoverApproval(req *GetTokenRecoverApproval
 
 	approvalSignature, err := svc.km.Sign(crypto.Keccak256(signData...))
 	if err != nil {
+		svc.metrics.IncApprovalErrorCount()
 		return nil, err
 	}
 	svc.logger.Debug().Str("approval_signature", hexutil.Encode(approvalSignature)).Msg("Signed ApprovalSignature")
+
+	svc.metrics.IncApprovalCount()
+	svc.metrics.ObserveApprovalDuration(float64(time.Since(approvalStartTime).Seconds()))
 	return &GetTokenRecoverApprovalResponse{
 		Amount:            big.NewInt(proof.Amount),
 		Proofs:            proof.Proof,

--- a/internal/module/approval/approval_test.go
+++ b/internal/module/approval/approval_test.go
@@ -26,7 +26,6 @@ const (
 func makeMockStore() (store.Store, error) {
 	initSDK()
 	return memory.NewMemoryStore(
-		path.Join(mockDataBasePath, "accounts.json"),
 		path.Join(mockDataBasePath, "merkle_proofs.json"),
 	)
 }

--- a/internal/module/approval/approval_test.go
+++ b/internal/module/approval/approval_test.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 
 	"github.com/bnb-chain/token-recover-approver/internal/config"
+	collector "github.com/bnb-chain/token-recover-approver/internal/metrics/prometheus"
 	"github.com/bnb-chain/token-recover-approver/internal/store"
 	"github.com/bnb-chain/token-recover-approver/internal/store/memory"
 	"github.com/bnb-chain/token-recover-approver/pkg/keymanager/local"
@@ -43,7 +45,7 @@ func makeMockSvc() (*ApprovalService, error) {
 	return NewApprovalService(&config.Config{
 		ChainID:    "Binance-Chain-Ganges",
 		MerkleRoot: mockMerkleRoot,
-	}, km, mockStore, &zerolog.Logger{})
+	}, km, mockStore, collector.NewCollector(prometheus.NewRegistry()), &zerolog.Logger{})
 }
 
 func initSDK() {

--- a/internal/module/http/http.go
+++ b/internal/module/http/http.go
@@ -2,8 +2,13 @@ package http
 
 import (
 	"net/http"
+	"net/http/pprof"
 
+	"github.com/felixge/fgprof"
+	"github.com/gorilla/context"
 	"github.com/julienschmidt/httprouter"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
 
 	"github.com/bnb-chain/token-recover-approver/internal/module/approval"
@@ -13,12 +18,16 @@ type HttpServer struct {
 	httpServer      *http.Server
 	approvalService *approval.ApprovalService
 
+	registry      *prometheus.Registry
+	metricsServer *http.Server
+
 	logger *zerolog.Logger
 }
 
-func NewHttpServer(approvalService *approval.ApprovalService, logger *zerolog.Logger) *HttpServer {
+func NewHttpServer(approvalService *approval.ApprovalService, registry *prometheus.Registry, logger *zerolog.Logger) *HttpServer {
 	return &HttpServer{
 		approvalService: approvalService,
+		registry:        registry,
 		logger:          logger,
 	}
 }
@@ -33,8 +42,30 @@ func (server *HttpServer) Run(addr string) error {
 	return server.httpServer.ListenAndServe()
 }
 
+func (server *HttpServer) RunMetrics(addr string, metricsPath string, enablePProf bool) error {
+	router := httprouter.New()
+	server.metricsServer = &http.Server{
+		Addr:    addr,
+		Handler: router,
+	}
+	server.setMetrics(router, metricsPath, enablePProf)
+	return server.metricsServer.ListenAndServe()
+}
+
 func (server *HttpServer) Shutdown() error {
-	return server.httpServer.Close()
+	err := server.httpServer.Close()
+	if err != nil {
+		return err
+	}
+
+	if server.metricsServer != nil {
+		err := server.metricsServer.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (server *HttpServer) setRouter(router *httprouter.Router) {
@@ -44,4 +75,66 @@ func (server *HttpServer) setRouter(router *httprouter.Router) {
 
 	router.GET("/ping", server.Ping)
 	router.POST("/approve", server.GetTokenRecoverApproval)
+}
+
+func (server *HttpServer) setMetrics(router *httprouter.Router, path string, enablePProf bool) {
+	server.logger.Info().Msg("metrics router list")
+	server.logger.Info().Msgf("GET %s", path)
+
+	router.GET(path, wrapHttpHandler(promhttp.HandlerFor(server.registry, promhttp.HandlerOpts{})))
+
+	if enablePProf {
+		server.logger.Info().Msg("pprof router list")
+		server.logger.Info().Msg("GET /debug/pprof/")
+		server.logger.Info().Msg("GET /debug/pprof/cmdline")
+		server.logger.Info().Msg("GET /debug/pprof/profile")
+		server.logger.Info().Msg("GET /debug/pprof/symbol")
+		server.logger.Info().Msg("GET /debug/pprof/trace")
+		server.logger.Info().Msg("GET /debug/pprof/goroutine")
+		server.logger.Info().Msg("GET /debug/pprof/heap")
+		server.logger.Info().Msg("GET /debug/pprof/allocs")
+		server.logger.Info().Msg("GET /debug/pprof/threadcreate")
+		server.logger.Info().Msg("GET /debug/pprof/block")
+		server.logger.Info().Msg("GET /debug/pprof/mutex")
+		server.logger.Info().Msg("GET /debug/fgprof")
+
+		router.GET("/debug/pprof/", wrapHttpHandleFunc(pprof.Index))
+		router.GET("/debug/pprof/cmdline", wrapHttpHandleFunc(pprof.Cmdline))
+		router.GET("/debug/pprof/profile", wrapHttpHandleFunc(pprof.Profile))
+		router.GET("/debug/pprof/symbol", wrapHttpHandleFunc(pprof.Symbol))
+		router.GET("/debug/pprof/trace", wrapHttpHandleFunc(pprof.Trace))
+		router.GET("/debug/pprof/goroutine", wrapHttpHandler(pprof.Handler("goroutine")))
+		router.GET("/debug/pprof/heap", wrapHttpHandler(pprof.Handler("heap")))
+		router.GET("/debug/pprof/allocs", wrapHttpHandler(pprof.Handler("allocs")))
+		router.GET("/debug/pprof/threadcreate", wrapHttpHandler(pprof.Handler("threadcreate")))
+		router.GET("/debug/pprof/block", wrapHttpHandler(pprof.Handler("block")))
+		router.GET("/debug/pprof/mutex", wrapHttpHandler(pprof.Handler("mutex")))
+		router.GET("/debug/fgprof", wrapHttpHandler(fgprof.Handler()))
+	}
+}
+
+// wrapHttpHandler transforms ususal handlers (http.Handler) of the standard library
+// package net/http into valid ones of httprouter by adding the params
+// (httprouter.Params) parameter.
+//
+// Use this function to add a context to middlewares or other things that should be
+// shared between both handler types.
+func wrapHttpHandler(h http.Handler) httprouter.Handle {
+	return func(rw http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		context.Set(req, "params", ps)
+		h.ServeHTTP(rw, req)
+	}
+}
+
+// wrapHttpHandler transforms ususal handlers (http.HandlerFunc) of the standard library
+// package net/http into valid ones of httprouter by adding the params
+// (httprouter.Params) parameter.
+//
+// Use this function to add a context to middlewares or other things that should be
+// shared between both handler types.
+func wrapHttpHandleFunc(h http.HandlerFunc) httprouter.Handle {
+	return func(rw http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		context.Set(req, "params", ps)
+		h(rw, req)
+	}
 }


### PR DESCRIPTION
### Description

1. implement metrics server
2. clear unused codes

### Rationale

implement the Prometheus metrics and pprof to make it easier to monitor the service. 

### Example

metrics
```
# HELP approval_count The total number of approvals.
# TYPE approval_count counter
approval_count 11
# HELP approval_duration_seconds A summary of the approval duration of the requests.
# TYPE approval_duration_seconds summary
approval_duration_seconds{quantile="0"} 0.000447334
approval_duration_seconds{quantile="0.25"} 0.000857958
approval_duration_seconds{quantile="0.5"} 0.000963791
approval_duration_seconds{quantile="0.75"} 0.00345625
approval_duration_seconds{quantile="1"} 0.01681425
approval_duration_seconds_sum 0.033380666999999996
approval_duration_seconds_count 11
# HELP approval_error_count The total number of approval errors.
# TYPE approval_error_count counter
approval_error_count 0
# HELP get_proof_data_duration_seconds A summary of the get proof data duration of the requests.
# TYPE get_proof_data_duration_seconds summary
get_proof_data_duration_seconds{quantile="0"} 3.208e-06
get_proof_data_duration_seconds{quantile="0.25"} 3.833e-06
get_proof_data_duration_seconds{quantile="0.5"} 3.916e-06
get_proof_data_duration_seconds{quantile="0.75"} 4.292e-06
get_proof_data_duration_seconds{quantile="1"} 8.291e-06
get_proof_data_duration_seconds_sum 4.7623e-05
get_proof_data_duration_seconds_count 11
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 2.2417e-05
go_gc_duration_seconds{quantile="0.25"} 2.2417e-05
go_gc_duration_seconds{quantile="0.5"} 0.000159667
go_gc_duration_seconds{quantile="0.75"} 0.000211749
go_gc_duration_seconds{quantile="1"} 0.000211749
go_gc_duration_seconds_sum 0.000393833
go_gc_duration_seconds_count 3
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 11
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.21.0"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 1.4560696e+07
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 1.6067136e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.452106e+06
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 13603
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 4.148256e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 1.4560696e+07
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 3.039232e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 1.7145856e+07
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 36480
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 2.981888e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 2.0185088e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.706691592740173e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 50083
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 9600
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 15600
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 176400
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 179256
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 1.9987096e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 1.447798e+06
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 786432
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 786432
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 2.8214536e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 14
# HELP merkle_proof_verification_duration_seconds A summary of the merkle proof verification duration of the requests.
# TYPE merkle_proof_verification_duration_seconds summary
merkle_proof_verification_duration_seconds{quantile="0"} 1.291e-06
merkle_proof_verification_duration_seconds{quantile="0.25"} 2.375e-06
merkle_proof_verification_duration_seconds{quantile="0.5"} 2.459e-06
merkle_proof_verification_duration_seconds{quantile="0.75"} 2.709e-06
merkle_proof_verification_duration_seconds{quantile="1"} 3.458e-06
merkle_proof_verification_duration_seconds_sum 2.7209000000000003e-05
merkle_proof_verification_duration_seconds_count 11
# HELP version_info Version information about this binary
# TYPE version_info gauge
version_info{build_date="20240131",git_commit="c7cb4d3ef599f197bc8a7c297dc300b12f68d4f7",version="fusion-audit-1.0-4-gc7cb4d3"} 0
```

pprof
```
go tool pprof -http=:8081 http://localhost:6060/debug/pprof/profile
go tool pprof -http=:8081 http://localhost:6060/debug/pprof/allocs
go tool pprof -http=:8081 http://localhost:6060/debug/pprof/goroutine
...
```

### Changes

Notable changes:
* add metrics pkg